### PR TITLE
Quick fix for bug #79

### DIFF
--- a/trunk/cf7-constantcontact.php
+++ b/trunk/cf7-constantcontact.php
@@ -695,6 +695,9 @@ class CTCTCF7 {
 	 */
 	public function save_form_settings( $args ) {
 		$cf_id = method_exists( $args, 'id' ) ? $args->id() : $args->id;
+		if ( $_POST['wpcf7-ctct']['accept'] == "" && strpos($_POST['wpcf7-ctct']['wpcf7-form'], " type:single ") !== false ) { 
+			$_POST['wpcf7-ctct']['accept'] = "ctctcf7_lists"; 
+		}
 		update_option( 'cf7_ctct_' . $cf_id, $_POST['wpcf7-ctct'] );
 	}
 

--- a/trunk/cf7-constantcontact.php
+++ b/trunk/cf7-constantcontact.php
@@ -695,7 +695,7 @@ class CTCTCF7 {
 	 */
 	public function save_form_settings( $args ) {
 		$cf_id = method_exists( $args, 'id' ) ? $args->id() : $args->id;
-		if ( $_POST['wpcf7-ctct']['accept'] == "" && strpos($_POST['wpcf7-ctct']['wpcf7-form'], " type:single ") !== false ) { 
+		if ( $_POST['wpcf7-ctct']['accept'] == "" ) { 
 			$_POST['wpcf7-ctct']['accept'] = "ctctcf7_lists"; 
 		}
 		update_option( 'cf7_ctct_' . $cf_id, $_POST['wpcf7-ctct'] );


### PR DESCRIPTION
Maybe not the most ideal way to fix this, but it does prevent the
'single' checkbox type from subscribing people who didn't opt in. Does
not affect the other types, although the dropdown select never did work
due to a different bug. A better way to fix this might be to add
'ctctcf7_lists' to the 'Opt-In Field' dropdown list on the Constant
Contact tab, but I haven't yet found where to add that - maybe something
the plugin author can address more adequately.